### PR TITLE
Gazebo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ At the end of this section the robot will be driving autonomously in simulation 
 
 Position the robot in the same spot as when the simulation starts and make sure runstop motion should is enabled (set to **true**).
 
-#### State estimator:
-
-The state estimator will be started by default but it has not converged.
-
 #### Start waypoint follower:
 
     roslaunch autorally_control waypointFollower.launch

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Verify runstop motion is enabled by looking at the `runstopMotionEnabled` paramt
 
 If you aren't using a gamepad, you will have to configure another source of runstop information for the platform to move:
 
-- Comment out line 93 of `autorally_gazebo/launch/autoRallyTrackGazeboSim.launch`
+- Comment out line 89 of `autorally_gazebo/launch/autoRallyTrackGazeboSim.launch`
 
 - ```rosrun rqt_publisher rqt_publisher```
 
@@ -128,12 +128,9 @@ At the end of this section the robot will be driving autonomously in simulation 
 
 Position the robot in the same spot as when the simulation starts and make sure runstop motion should is enabled (set to **true**).
 
-#### Start state estimator:
+#### State estimator:
 
-In `autorally_core/launch/state_estimator.launch` change `InvertY` and `InvertZ` to **false**, then:
-
-    rosparam set /gps_imu/FixedInitialPose true
-    roslaunch autorally_core state_estimator.launch
+The state estimator will be started by default but it has not converged.
 
 #### Start waypoint follower:
 

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -32,7 +32,7 @@ limitations under the License.
 <launch>
   <env name="GAZEBO_MODEL_PATH" value="$(find autorally_description)"/>
   <env name="GAZEBO_RESOURCE_PATH" value="$(find autorally_description)"/>
-  <arg name="namespace" default="autorally_platform"/>
+  <arg name="namespace" default=""/>
   <arg name="world_name" default="model://urdf/populated_AR.world"/>
   <arg name="cmd_timeout" default="0.5"/>
 
@@ -47,41 +47,44 @@ limitations under the License.
   <arg name="pitch" default="0.0"/>
   <arg name="yaw" default="0.785498"/>
 
-  <include file="$(find autorally_description)/launch/autoRallyPlatform.launch">
-    <arg name="namespace" value="$(arg namespace)"/>
+  <!-- Create the world. -->
+  <include file="$(find autorally_gazebo)/launch/autoRallyTrackWorld.launch">
+    <arg name="world_name" value="$(arg world_name)"/>
   </include>
 
-  <!-- Remap to same topics as the actual robot (this doesn't seem to work in Kinetic) -->
-  <remap from="/$(arg namespace)/camera/left" to="/left_camera" />
-  <remap from="/$(arg namespace)/camera/right" to="/right_camera" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find autorally_description)/urdf/autoRallyPlatform.urdf.xacro prefix:=/"/>
 
-  <group ns="$(arg namespace)">
-    <!-- Create the world. -->
-    <include file="$(find autorally_gazebo)/launch/autoRallyTrackWorld.launch">
-      <arg name="world_name" value="$(arg world_name)"/>
-    </include>
+  <node name="autoRally_state_publisher" pkg="robot_state_publisher"
+        type="robot_state_publisher">
+    <param name="publish_frequency" value="50.0"/>
+  </node>
 
-    <!-- Spawn the vehicle. -->
-    <node name="spawn_platform" pkg="gazebo_ros" type="spawn_model"
-          args="-urdf -param robot_description -model autoRallyPlatform
-                -gazebo_namespace /$(arg namespace)/gazebo
-                -x $(arg x) -y $(arg y) -z $(arg z)
-                -R $(arg roll) -P $(arg pitch) -Y $(arg yaw)"/>
 
-    <!-- Load the joint controllers. One of these publishes the joint states
-         to joint_states. -->
-    <node name="controller_spawner" pkg="controller_manager" type="spawner"
+  <node name="spawn_platform" pkg="gazebo_ros" type="spawn_model"
+        args="-urdf -param robot_description -model $(arg namespace)
+              -gazebo_namespace /gazebo
+              -x $(arg x) -y $(arg y) -z $(arg z)
+              -R $(arg roll) -P $(arg pitch) -Y $(arg yaw)"/>
+
+  <!-- load controllers -->
+  <node name="controller_spawner" pkg="controller_manager" type="spawner"
           args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml"/>
 
-    <!-- Control the steering, axle, and shock absorber joints. -->
-    <node name="autorally_controller" pkg="autorally_gazebo"
-          type="autorally_controller.py" output="screen">
-      <param name="cmd_timeout" value="$(arg cmd_timeout)"/>
-      <rosparam file="$(find autorally_gazebo)/config/autoRallyPlatformCtrlrParams.yaml" command="load"/>
-      <rosparam param="chassisCommandProirities" command="load" file="$(env AR_CONFIG_PATH)/chassisCommandPriorities.yaml" />
-    </node>
+  <!-- Control the steering, axle, and shock absorber joints. -->
+  <node name="autorally_controller" pkg="autorally_gazebo"
+        type="autorally_controller.py" output="screen">
+    <param name="cmd_timeout" value="$(arg cmd_timeout)"/>
+    <param name="vehicle_prefix" value="$(arg namespace)"/>
+    <rosparam file="$(find autorally_gazebo)/config/autoRallyPlatformCtrlrParams.yaml" command="load"/>
+    <rosparam param="chassisCommandProirities" command="load" file="$(env AR_CONFIG_PATH)/chassisCommandPriorities.yaml"/>
+  </node>
 
-  </group>
+  <include file="$(find autorally_core)/launch/stateEstimator.launch">
+    <arg name="sim" value="true"/>
+    <arg name="InvertY" value="false"/>
+    <arg name="InvertZ" value="false"/>
+    <arg name="FixedInitialPose" value="true"/>
+  </include>
   <include file="$(find autorally_core)/launch/autorally_core_manager.launch" />
-  <include file="$(find autorally_control)/launch/joystickController.launch" />
+  <!--<include file="$(find autorally_control)/launch/joystickController.launch" />-->
 </launch>

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -86,5 +86,5 @@ limitations under the License.
     <arg name="FixedInitialPose" value="true"/>
   </include>
   <include file="$(find autorally_core)/launch/autorally_core_manager.launch" />
-  <!--<include file="$(find autorally_control)/launch/joystickController.launch" />-->
+  <include file="$(find autorally_control)/launch/joystickController.launch" />
 </launch>

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -52,6 +52,10 @@ limitations under the License.
     <arg name="world_name" value="$(arg world_name)"/>
   </include>
 
+  <!-- Remap to same topics as the actual robot (this doesn't seem to work in Kinetic) -->
+  <remap from="camera/left" to="left_camera"/>
+  <remap from="camera/right" to="right_camera"/>
+
   <param name="robot_description" command="$(find xacro)/xacro $(find autorally_description)/urdf/autoRallyPlatform.urdf.xacro prefix:=/"/>
 
   <node name="autoRally_state_publisher" pkg="robot_state_publisher"

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -52,10 +52,6 @@ limitations under the License.
     <arg name="world_name" value="$(arg world_name)"/>
   </include>
 
-  <!-- Remap to same topics as the actual robot (this doesn't seem to work in Kinetic) -->
-  <remap from="camera/left" to="left_camera"/>
-  <remap from="camera/right" to="right_camera"/>
-
   <param name="robot_description" command="$(find xacro)/xacro $(find autorally_description)/urdf/autoRallyPlatform.urdf.xacro prefix:=/"/>
 
   <node name="autoRally_state_publisher" pkg="robot_state_publisher"

--- a/autorally_gazebo/launch/autoRallyTrackWorld.launch
+++ b/autorally_gazebo/launch/autoRallyTrackWorld.launch
@@ -35,7 +35,7 @@
   <!-- start gazebo server-->
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="false" output="screen"
         args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" >
-    <!-- Remap to same topics as the actual robot (this doesn't seem to work in Kinetic) -->
+    <!-- Remap to same topics as the actual robot (this doesn't seem to work with multiple vehicles) -->
     <remap from="camera/left" to="left_camera"/>
     <remap from="camera/right" to="right_camera"/>
   </node>

--- a/autorally_gazebo/launch/autoRallyTrackWorld.launch
+++ b/autorally_gazebo/launch/autoRallyTrackWorld.launch
@@ -34,7 +34,11 @@
 
   <!-- start gazebo server-->
   <node name="gazebo" pkg="gazebo_ros" type="$(arg script_type)" respawn="false" output="screen"
-      args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" />
+        args="$(arg command_arg1) $(arg command_arg2) $(arg command_arg3) -e $(arg physics) $(arg extra_gazebo_args) $(arg world_name)" >
+    <!-- Remap to same topics as the actual robot (this doesn't seem to work in Kinetic) -->
+    <remap from="camera/left" to="left_camera"/>
+    <remap from="camera/right" to="right_camera"/>
+  </node>
 
   <!-- start gazebo client -->
   <group if="$(arg gui)">

--- a/autorally_gazebo/launch/singlePlatform.launch
+++ b/autorally_gazebo/launch/singlePlatform.launch
@@ -72,7 +72,7 @@ limitations under the License.
     <param name="cmd_timeout" value="$(arg cmd_timeout)"/>
     <param name="vehicle_prefix" value="$(arg namespace)"/>
     <rosparam file="$(find autorally_gazebo)/config/autoRallyPlatformCtrlrParams.yaml" command="load"/>
-    <rosparam param="chassisCommandProirities" command="load" file="$(env AR_CONFIG_PATH)/chassisCommandPriorities.yaml" />
+    <rosparam param="chassisCommandProirities" command="load" file="$(env AR_CONFIG_PATH)/chassisCommandPriorities.yaml"/>
   </node>
 
   <include file="$(find autorally_core)/launch/stateEstimator.launch">
@@ -81,4 +81,5 @@ limitations under the License.
     <arg name="InvertZ" value="false"/>
     <arg name="FixedInitialPose" value="true"/>
   </include>
+  <include file="$(find autorally_core)/launch/autorally_core_manager.launch" />
 </launch>


### PR DESCRIPTION
This fixes any namespace issue that were occurring during our recent install fest. I was also able to get the remapping of camera topics but only on a single vehicle. I continue to keep trying to fix it for multiple vehicles as well. 