### PR TITLE
Script to find first joystick

### DIFF
--- a/autorally_control/launch/joystickController.launch
+++ b/autorally_control/launch/joystickController.launch
@@ -2,7 +2,7 @@
   <include file="$(find autorally_core)/launch/hardware.machine" />
 
   <node name="joy_node" pkg="joy" type="joy_node" output="screen" machine="autorally-ocs">
-    <param name="dev" value="/dev/input/js0" />
+    <param name="dev" value="$(optenv AR_JOYSTICK /dev/input/js0)" />
     <param name="deadzone" value="0.01" />
     <param name="autorepeat_rate" value="10" />
     <param name="coalesce_interval" value="0.01" />
@@ -13,7 +13,7 @@
     <param name="steeringDamping" value="1.0" />
     <param name="throttleAxis" value="1" />
     <param name="steeringAxis" value="3" />
-    <rosparam param="runstopToggleButtons">[0, 1, 2, 3]</rosparam>
+    <rosparam param="runstopToggleButtons">[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]</rosparam>
     <param name="safeSpeedIncButton" value="0" />
     <param name="safeSpeedDecButton" value="3" />
     <param name="safeSpeedZeroButton1" value="1" />

--- a/autorally_control/launch/joystickController.launch
+++ b/autorally_control/launch/joystickController.launch
@@ -13,7 +13,7 @@
     <param name="steeringDamping" value="1.0" />
     <param name="throttleAxis" value="1" />
     <param name="steeringAxis" value="3" />
-    <rosparam param="runstopToggleButtons">[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]</rosparam>
+    <rosparam param="runstopToggleButtons">[0, 1, 2, 3]</rosparam>
     <param name="safeSpeedIncButton" value="0" />
     <param name="safeSpeedDecButton" value="3" />
     <param name="safeSpeedZeroButton1" value="1" />

--- a/autorally_util/setupEnvVariables.sh
+++ b/autorally_util/setupEnvVariables.sh
@@ -117,3 +117,16 @@ if [[ $DEBUG == true ]]; then
     echo "AR_LEFTCAM_CONNECTED  = ${AR_LEFTCAM_CONNECTED}"
 fi
 
+for device in /dev/input/js*; do
+    AR_JOYSTICK=$(udevadm info -n $device -q property --export | grep ID_INPUT_JOYSTICK)
+    AR_JOYSTICK=${AR_JOYSTICK#*=}
+    if [[ $AR_JOYSTICK == "'1'" ]]; then
+        export AR_JOYSTICK="$device"
+        break
+    fi
+    AR_JOYSTICK=none
+done
+
+YELLOW='\033[0;33m'
+[[ -z $AR_JOYSTICK ]] && echo "${YELLOW}[WARNING] No joystick detected."
+


### PR DESCRIPTION
Some mice register as joysticks on Linux, and always selecting /dev/input/js0 can select the mouse instead of the target gamepad. I wrote a simple script which is part of the setupEnvVariables.sh to find the first /dev/input/js* which is actually a joystick and not a mouse. This is then set as an environment variable used by the joystickController.launch script when loading the Gazebo environment.