### PR TITLE
Fix for breaking zsh autocomplete when sourcing in zshrc.

### DIFF
--- a/autorally_util/setupEnvVariables.sh
+++ b/autorally_util/setupEnvVariables.sh
@@ -57,7 +57,7 @@ export AR_RIGHTCAM_CONNECTED=false
 export AR_LEFTCAM_CONNECTED=false
 export AR_RIGHTCAM=none
 export AR_LEFTCAM=none
-
+PREV_IFS=$IFS
 IFS=$'\n'
 
 ## Get list of PointGrey Flea3 devices connected to computer
@@ -132,3 +132,4 @@ RESET=`tput sgr0`
 if [[ -z $AR_JOYSTICK ]]; then
     echo "${YELLOW}[WARNING] No joystick detected.${RESET}"
 fi
+IFS=$PREV_IFS


### PR DESCRIPTION
Sourcing this file in my zshrc would break zsh's autocomplete. This fixed the issue.