### PR TITLE
Fixes To Allow The README Instructions To Work As Advertised

### DIFF
--- a/autorally_gazebo/launch/autoRallyJumpGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyJumpGazeboSim.launch
@@ -80,7 +80,7 @@ rosservice call autorally_platform/gazebo/delete_model '{model_name: autoRallyPl
     <!-- Load the joint controllers. One of these publishes the joint states
          to joint_states. -->
     <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml"/>
+          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml --timeout 120"/>
 
     <!-- Control the steering, axle, and shock absorber joints. -->
     <node name="autorally_controller" pkg="autorally_gazebo"

--- a/autorally_gazebo/launch/autoRallyTrackCCRFGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackCCRFGazeboSim.launch
@@ -68,7 +68,7 @@ limitations under the License.
 
   <!-- load controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml"/>
+          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml --timeout 120"/>
 
   <!-- Control the steering, axle, and shock absorber joints. -->
   <node name="autorally_controller" pkg="autorally_gazebo"

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -68,7 +68,7 @@ limitations under the License.
 
   <!-- load controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml"/>
+          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml --timeout 120"/>
 
   <!-- Control the steering, axle, and shock absorber joints. -->
   <node name="autorally_controller" pkg="autorally_gazebo"

--- a/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
+++ b/autorally_gazebo/launch/autoRallyTrackGazeboSim.launch
@@ -84,6 +84,15 @@ limitations under the License.
         type="ground_truth_republisher.py" output="screen">
   </node>
 
+
+  <!-- Run state estimator -->
+  <include file="$(find autorally_core)/launch/stateEstimator.launch">
+    <arg name="sim" value="true"/>
+    <arg name="InvertY" value="false"/>
+    <arg name="InvertZ" value="false"/>
+    <arg name="FixedInitialPose" value="true"/>
+  </include>
+
   <include file="$(find autorally_core)/launch/autorally_core_manager.launch" />
   <include file="$(find autorally_control)/launch/joystickController.launch" />
 </launch>

--- a/autorally_gazebo/launch/singlePlatform.launch
+++ b/autorally_gazebo/launch/singlePlatform.launch
@@ -64,7 +64,7 @@ limitations under the License.
 
   <!-- load joint controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml"/>
+          args="$(find autorally_gazebo)/config/autoRallyPlatformJointCtrlrParams.yaml --timeout 120"/>
 
   <!-- Control the steering, axle, and shock absorber joints. -->
   <node name="autorally_controller" pkg="autorally_gazebo"


### PR DESCRIPTION
- added a timeout on the controller spawner in all launch files because if gazebo takes to long to startup (`autoRallyTrackGazeboSim.launch ` takes over a minute to launch on my machine)
- added the state estimator node to `autoRallyTrackGazeboSim.launch`. Without this there is no state for the `ConstantSpeedController` to use for feedback, and the vehicle will simply not move.

(@ian-mitchell FYI)